### PR TITLE
chg: tests now work with submodule capture_samples & added redirect test

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -28,6 +28,8 @@ jobs:
 
     - name: Test with nosetests
       run: |
+	
+	git submodule update --init --recursive
         poetry run nosetests --with-coverage --cover-xml --cover-package=har2tree tests/test.py
         poetry run nosetests --with-coverage --cover-xml --cover-package=har2tree tests/simple_test.py
         poetry run mypy .

--- a/tests/simple_test.py
+++ b/tests/simple_test.py
@@ -10,20 +10,24 @@ import uuid
 
 class SimpleTest(unittest.TestCase):
 
-    index_tree: CrawledTree
+    http_redirect_tree: CrawledTree
 
     @classmethod
     def setUpClass(cls) -> None:
-        test_dir = Path(os.path.abspath(os.path.dirname(__file__))) / 'data' / 'simple'
-        har_to_process = [test_dir / 'heroku_index.har']
-        cls.index_tree = CrawledTree(har_to_process, str(uuid.uuid4()))
+        test_dir = Path(os.path.abspath(os.path.dirname(__file__))) / 'capture_samples' / 'http_redirect'
+        har_to_process = [test_dir / '0.har']
+        cls.http_redirect_tree = CrawledTree(har_to_process, str(uuid.uuid4()))
 
     def test_root_url(self) -> None:
-        self.assertEqual(self.index_tree.root_url, 'https://lookyloo-testing.herokuapp.com/')
+        self.assertEqual(self.http_redirect_tree.root_url, 'https://lookyloo-testing.herokuapp.com/redirect_http')
 
     def test_user_agent(self) -> None:
-        self.assertEqual(self.index_tree.user_agent, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36")
-
-
+        self.assertEqual(self.http_redirect_tree.user_agent, "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b")
+    
+    def test_redirects(self) -> None:
+        self.assertEqual(self.http_redirect_tree.redirects[1], "https://www.youtube.com/watch?v=iwGFalTRHDA")
+    
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main() 
+
+


### PR DESCRIPTION
- path was changed to work with submodule capture_samples
- redirect test added for herokuapp redirect_http